### PR TITLE
Replaced skipUnlessHasTestFile decorator with unittest.SkipTest

### DIFF
--- a/tests/regf.py
+++ b/tests/regf.py
@@ -4,7 +4,6 @@
 
 from __future__ import unicode_literals
 
-import os
 import unittest
 
 from dfwinreg import errors
@@ -73,8 +72,7 @@ class REGFWinRegistryFileTest(test_lib.BaseTestCase):
   def testOpenClose(self):
     """Tests the Open and Close functions."""
     test_path = self._GetTestFilePath(['NTUSER.DAT'])
-    if not os.path.exists(test_path):
-      raise unittest.SkipTest('missing test file: NTUSER.DAT')
+    self._SkipIfPathNotExists(test_path)
 
     registry_file = regf.REGFWinRegistryFile()
 
@@ -85,12 +83,10 @@ class REGFWinRegistryFileTest(test_lib.BaseTestCase):
   def testGetRootKey(self):
     """Tests the GetRootKey function."""
     dat_test_path = self._GetTestFilePath(['NTUSER.DAT'])
-    if not os.path.exists(dat_test_path):
-      raise unittest.SkipTest('missing test file: NTUSER.DAT')
+    self._SkipIfPathNotExists(dat_test_path)
 
     log_test_path = self._GetTestFilePath(['NTUSER.DAT.LOG'])
-    if not os.path.exists(log_test_path):
-      raise unittest.SkipTest('missing test file: NTUSER.DAT.LOG')
+    self._SkipIfPathNotExists(log_test_path)
 
     registry_file = regf.REGFWinRegistryFile()
 
@@ -116,8 +112,7 @@ class REGFWinRegistryFileTest(test_lib.BaseTestCase):
   def testGetKeyByPath(self):
     """Tests the GetKeyByPath function."""
     test_path = self._GetTestFilePath(['NTUSER.DAT'])
-    if not os.path.exists(test_path):
-      raise unittest.SkipTest('missing test file: NTUSER.DAT')
+    self._SkipIfPathNotExists(test_path)
 
     registry_file = regf.REGFWinRegistryFile()
 
@@ -147,12 +142,10 @@ class REGFWinRegistryFileTest(test_lib.BaseTestCase):
   def testRecurseKeys(self):
     """Tests the RecurseKeys function."""
     dat_test_path = self._GetTestFilePath(['NTUSER.DAT'])
-    if not os.path.exists(dat_test_path):
-      raise unittest.SkipTest('missing test file: NTUSER.DAT')
+    self._SkipIfPathNotExists(dat_test_path)
 
     log_test_path = self._GetTestFilePath(['NTUSER.DAT.LOG'])
-    if not os.path.exists(log_test_path):
-      raise unittest.SkipTest('missing test file: NTUSER.DAT.LOG')
+    self._SkipIfPathNotExists(log_test_path)
 
     registry_file = regf.REGFWinRegistryFile()
 
@@ -183,8 +176,7 @@ class REGFWinRegistryKeyTest(test_lib.BaseTestCase):
   def testProperties(self):
     """Tests the properties functions."""
     test_path = self._GetTestFilePath(['NTUSER.DAT'])
-    if not os.path.exists(test_path):
-      raise unittest.SkipTest('missing test file: NTUSER.DAT')
+    self._SkipIfPathNotExists(test_path)
 
     registry_file = regf.REGFWinRegistryFile()
 
@@ -216,8 +208,7 @@ class REGFWinRegistryKeyTest(test_lib.BaseTestCase):
   def testGetSubkeyByIndex(self):
     """Tests the GetSubkeyByIndex function."""
     test_path = self._GetTestFilePath(['NTUSER.DAT'])
-    if not os.path.exists(test_path):
-      raise unittest.SkipTest('missing test file: NTUSER.DAT')
+    self._SkipIfPathNotExists(test_path)
 
     registry_file = regf.REGFWinRegistryFile(
         key_path_prefix='HKEY_CURRENT_USER')
@@ -247,8 +238,7 @@ class REGFWinRegistryKeyTest(test_lib.BaseTestCase):
   def testGetSubkeyByName(self):
     """Tests the GetSubkeyByName function."""
     test_path = self._GetTestFilePath(['NTUSER.DAT'])
-    if not os.path.exists(test_path):
-      raise unittest.SkipTest('missing test file: NTUSER.DAT')
+    self._SkipIfPathNotExists(test_path)
 
     registry_file = regf.REGFWinRegistryFile(
         key_path_prefix='HKEY_CURRENT_USER')
@@ -275,8 +265,7 @@ class REGFWinRegistryKeyTest(test_lib.BaseTestCase):
   def testGetSubkeyByPath(self):
     """Tests the GetSubkeyByPath function."""
     test_path = self._GetTestFilePath(['NTUSER.DAT'])
-    if not os.path.exists(test_path):
-      raise unittest.SkipTest('missing test file: NTUSER.DAT')
+    self._SkipIfPathNotExists(test_path)
 
     registry_file = regf.REGFWinRegistryFile(
         key_path_prefix='HKEY_CURRENT_USER')
@@ -303,8 +292,7 @@ class REGFWinRegistryKeyTest(test_lib.BaseTestCase):
   def testGetSubkeys(self):
     """Tests the GetSubkeys function."""
     test_path = self._GetTestFilePath(['NTUSER.DAT'])
-    if not os.path.exists(test_path):
-      raise unittest.SkipTest('missing test file: NTUSER.DAT')
+    self._SkipIfPathNotExists(test_path)
 
     registry_file = regf.REGFWinRegistryFile()
 
@@ -322,8 +310,7 @@ class REGFWinRegistryKeyTest(test_lib.BaseTestCase):
   def testGetValueByName(self):
     """Tests the GetValueByName function."""
     test_path = self._GetTestFilePath(['NTUSER.DAT'])
-    if not os.path.exists(test_path):
-      raise unittest.SkipTest('missing test file: NTUSER.DAT')
+    self._SkipIfPathNotExists(test_path)
 
     registry_file = regf.REGFWinRegistryFile()
 
@@ -354,8 +341,7 @@ class REGFWinRegistryKeyTest(test_lib.BaseTestCase):
   def testGetValues(self):
     """Tests the GetValues function."""
     test_path = self._GetTestFilePath(['NTUSER.DAT'])
-    if not os.path.exists(test_path):
-      raise unittest.SkipTest('missing test file: NTUSER.DAT')
+    self._SkipIfPathNotExists(test_path)
 
     registry_file = regf.REGFWinRegistryFile()
 
@@ -373,8 +359,7 @@ class REGFWinRegistryKeyTest(test_lib.BaseTestCase):
   def testRecurseKeys(self):
     """Tests the RecurseKeys function."""
     test_path = self._GetTestFilePath(['NTUSER.DAT'])
-    if not os.path.exists(test_path):
-      raise unittest.SkipTest('missing test file: NTUSER.DAT')
+    self._SkipIfPathNotExists(test_path)
 
     registry_file = regf.REGFWinRegistryFile()
 
@@ -397,8 +382,7 @@ class REGFWinRegistryValueTest(test_lib.BaseTestCase):
   def testProperties(self):
     """Tests the properties functions on a NTUSER.DAT file."""
     test_path = self._GetTestFilePath(['NTUSER.DAT'])
-    if not os.path.exists(test_path):
-      raise unittest.SkipTest('missing test file: NTUSER.DAT')
+    self._SkipIfPathNotExists(test_path)
 
     registry_file = regf.REGFWinRegistryFile()
 
@@ -456,8 +440,7 @@ class REGFWinRegistryValueTest(test_lib.BaseTestCase):
   def testGetDataAsObject(self):
     """Tests the GetDataAsObject function."""
     test_path = self._GetTestFilePath(['NTUSER.DAT'])
-    if not os.path.exists(test_path):
-      raise unittest.SkipTest('missing test file: NTUSER.DAT')
+    self._SkipIfPathNotExists(test_path)
 
     registry_file = regf.REGFWinRegistryFile()
 

--- a/tests/regf.py
+++ b/tests/regf.py
@@ -4,6 +4,7 @@
 
 from __future__ import unicode_literals
 
+import os
 import unittest
 
 from dfwinreg import errors
@@ -69,26 +70,31 @@ class FakePyREGFValue(object):
 class REGFWinRegistryFileTest(test_lib.BaseTestCase):
   """Tests for the REGF Windows Registry file."""
 
-  @test_lib.skipUnlessHasTestFile(['NTUSER.DAT'])
   def testOpenClose(self):
     """Tests the Open and Close functions."""
-    path = self._GetTestFilePath(['NTUSER.DAT'])
+    test_path = self._GetTestFilePath(['NTUSER.DAT'])
+    if not os.path.exists(test_path):
+      raise unittest.SkipTest('missing test file: NTUSER.DAT')
 
     registry_file = regf.REGFWinRegistryFile()
 
-    with open(path, 'rb') as file_object:
+    with open(test_path, 'rb') as file_object:
       registry_file.Open(file_object)
       registry_file.Close()
 
-  @test_lib.skipUnlessHasTestFile(['NTUSER.DAT'])
-  @test_lib.skipUnlessHasTestFile(['NTUSER.DAT.LOG'])
   def testGetRootKey(self):
     """Tests the GetRootKey function."""
-    path = self._GetTestFilePath(['NTUSER.DAT'])
+    dat_test_path = self._GetTestFilePath(['NTUSER.DAT'])
+    if not os.path.exists(dat_test_path):
+      raise unittest.SkipTest('missing test file: NTUSER.DAT')
+
+    log_test_path = self._GetTestFilePath(['NTUSER.DAT.LOG'])
+    if not os.path.exists(log_test_path):
+      raise unittest.SkipTest('missing test file: NTUSER.DAT.LOG')
 
     registry_file = regf.REGFWinRegistryFile()
 
-    with open(path, 'rb') as file_object:
+    with open(dat_test_path, 'rb') as file_object:
       registry_file.Open(file_object)
 
       registry_key = registry_file.GetRootKey()
@@ -97,11 +103,9 @@ class REGFWinRegistryFileTest(test_lib.BaseTestCase):
 
       registry_file.Close()
 
-    path = self._GetTestFilePath(['NTUSER.DAT.LOG'])
-
     registry_file = regf.REGFWinRegistryFile()
 
-    with open(path, 'rb') as file_object:
+    with open(log_test_path, 'rb') as file_object:
       registry_file.Open(file_object)
 
       root_key = registry_file.GetRootKey()
@@ -109,14 +113,15 @@ class REGFWinRegistryFileTest(test_lib.BaseTestCase):
 
       registry_file.Close()
 
-  @test_lib.skipUnlessHasTestFile(['NTUSER.DAT'])
   def testGetKeyByPath(self):
     """Tests the GetKeyByPath function."""
-    path = self._GetTestFilePath(['NTUSER.DAT'])
+    test_path = self._GetTestFilePath(['NTUSER.DAT'])
+    if not os.path.exists(test_path):
+      raise unittest.SkipTest('missing test file: NTUSER.DAT')
 
     registry_file = regf.REGFWinRegistryFile()
 
-    with open(path, 'rb') as file_object:
+    with open(test_path, 'rb') as file_object:
       registry_file.Open(file_object)
 
       key_path = '\\'
@@ -139,15 +144,19 @@ class REGFWinRegistryFileTest(test_lib.BaseTestCase):
 
       registry_file.Close()
 
-  @test_lib.skipUnlessHasTestFile(['NTUSER.DAT'])
-  @test_lib.skipUnlessHasTestFile(['NTUSER.DAT.LOG'])
   def testRecurseKeys(self):
     """Tests the RecurseKeys function."""
-    path = self._GetTestFilePath(['NTUSER.DAT'])
+    dat_test_path = self._GetTestFilePath(['NTUSER.DAT'])
+    if not os.path.exists(dat_test_path):
+      raise unittest.SkipTest('missing test file: NTUSER.DAT')
+
+    log_test_path = self._GetTestFilePath(['NTUSER.DAT.LOG'])
+    if not os.path.exists(log_test_path):
+      raise unittest.SkipTest('missing test file: NTUSER.DAT.LOG')
 
     registry_file = regf.REGFWinRegistryFile()
 
-    with open(path, 'rb') as file_object:
+    with open(dat_test_path, 'rb') as file_object:
       registry_file.Open(file_object)
 
       registry_keys = list(registry_file.RecurseKeys())
@@ -155,11 +164,9 @@ class REGFWinRegistryFileTest(test_lib.BaseTestCase):
 
     self.assertEqual(len(registry_keys), 1597)
 
-    path = self._GetTestFilePath(['NTUSER.DAT.LOG'])
-
     registry_file = regf.REGFWinRegistryFile()
 
-    with open(path, 'rb') as file_object:
+    with open(log_test_path, 'rb') as file_object:
       registry_file.Open(file_object)
 
       registry_keys = list(registry_file.RecurseKeys())
@@ -173,14 +180,15 @@ class REGFWinRegistryKeyTest(test_lib.BaseTestCase):
 
   # pylint: disable=protected-access
 
-  @test_lib.skipUnlessHasTestFile(['NTUSER.DAT'])
   def testProperties(self):
     """Tests the properties functions."""
-    path = self._GetTestFilePath(['NTUSER.DAT'])
+    test_path = self._GetTestFilePath(['NTUSER.DAT'])
+    if not os.path.exists(test_path):
+      raise unittest.SkipTest('missing test file: NTUSER.DAT')
 
     registry_file = regf.REGFWinRegistryFile()
 
-    with open(path, 'rb') as file_object:
+    with open(test_path, 'rb') as file_object:
       registry_file.Open(file_object)
 
       key_path = '\\Software'
@@ -205,15 +213,16 @@ class REGFWinRegistryKeyTest(test_lib.BaseTestCase):
 
       registry_file.Close()
 
-  @test_lib.skipUnlessHasTestFile(['NTUSER.DAT'])
   def testGetSubkeyByIndex(self):
     """Tests the GetSubkeyByIndex function."""
-    path = self._GetTestFilePath(['NTUSER.DAT'])
+    test_path = self._GetTestFilePath(['NTUSER.DAT'])
+    if not os.path.exists(test_path):
+      raise unittest.SkipTest('missing test file: NTUSER.DAT')
 
     registry_file = regf.REGFWinRegistryFile(
         key_path_prefix='HKEY_CURRENT_USER')
 
-    with open(path, 'rb') as file_object:
+    with open(test_path, 'rb') as file_object:
       registry_file.Open(file_object)
 
       registry_key = registry_file.GetRootKey()
@@ -235,15 +244,16 @@ class REGFWinRegistryKeyTest(test_lib.BaseTestCase):
 
       registry_file.Close()
 
-  @test_lib.skipUnlessHasTestFile(['NTUSER.DAT'])
   def testGetSubkeyByName(self):
     """Tests the GetSubkeyByName function."""
-    path = self._GetTestFilePath(['NTUSER.DAT'])
+    test_path = self._GetTestFilePath(['NTUSER.DAT'])
+    if not os.path.exists(test_path):
+      raise unittest.SkipTest('missing test file: NTUSER.DAT')
 
     registry_file = regf.REGFWinRegistryFile(
         key_path_prefix='HKEY_CURRENT_USER')
 
-    with open(path, 'rb') as file_object:
+    with open(test_path, 'rb') as file_object:
       registry_file.Open(file_object)
 
       registry_key = registry_file.GetRootKey()
@@ -262,15 +272,16 @@ class REGFWinRegistryKeyTest(test_lib.BaseTestCase):
 
       registry_file.Close()
 
-  @test_lib.skipUnlessHasTestFile(['NTUSER.DAT'])
   def testGetSubkeyByPath(self):
     """Tests the GetSubkeyByPath function."""
-    path = self._GetTestFilePath(['NTUSER.DAT'])
+    test_path = self._GetTestFilePath(['NTUSER.DAT'])
+    if not os.path.exists(test_path):
+      raise unittest.SkipTest('missing test file: NTUSER.DAT')
 
     registry_file = regf.REGFWinRegistryFile(
         key_path_prefix='HKEY_CURRENT_USER')
 
-    with open(path, 'rb') as file_object:
+    with open(test_path, 'rb') as file_object:
       registry_file.Open(file_object)
 
       registry_key = registry_file.GetRootKey()
@@ -289,14 +300,15 @@ class REGFWinRegistryKeyTest(test_lib.BaseTestCase):
 
       registry_file.Close()
 
-  @test_lib.skipUnlessHasTestFile(['NTUSER.DAT'])
   def testGetSubkeys(self):
     """Tests the GetSubkeys function."""
-    path = self._GetTestFilePath(['NTUSER.DAT'])
+    test_path = self._GetTestFilePath(['NTUSER.DAT'])
+    if not os.path.exists(test_path):
+      raise unittest.SkipTest('missing test file: NTUSER.DAT')
 
     registry_file = regf.REGFWinRegistryFile()
 
-    with open(path, 'rb') as file_object:
+    with open(test_path, 'rb') as file_object:
       registry_file.Open(file_object)
 
       key_path = '\\Software'
@@ -307,14 +319,15 @@ class REGFWinRegistryKeyTest(test_lib.BaseTestCase):
 
       registry_file.Close()
 
-  @test_lib.skipUnlessHasTestFile(['NTUSER.DAT'])
   def testGetValueByName(self):
     """Tests the GetValueByName function."""
-    path = self._GetTestFilePath(['NTUSER.DAT'])
+    test_path = self._GetTestFilePath(['NTUSER.DAT'])
+    if not os.path.exists(test_path):
+      raise unittest.SkipTest('missing test file: NTUSER.DAT')
 
     registry_file = regf.REGFWinRegistryFile()
 
-    with open(path, 'rb') as file_object:
+    with open(test_path, 'rb') as file_object:
       registry_file.Open(file_object)
 
       registry_key = registry_file.GetKeyByPath('\\Console')
@@ -338,14 +351,15 @@ class REGFWinRegistryKeyTest(test_lib.BaseTestCase):
 
       registry_file.Close()
 
-  @test_lib.skipUnlessHasTestFile(['NTUSER.DAT'])
   def testGetValues(self):
     """Tests the GetValues function."""
-    path = self._GetTestFilePath(['NTUSER.DAT'])
+    test_path = self._GetTestFilePath(['NTUSER.DAT'])
+    if not os.path.exists(test_path):
+      raise unittest.SkipTest('missing test file: NTUSER.DAT')
 
     registry_file = regf.REGFWinRegistryFile()
 
-    with open(path, 'rb') as file_object:
+    with open(test_path, 'rb') as file_object:
       registry_file.Open(file_object)
 
       key_path = '\\Console'
@@ -356,14 +370,15 @@ class REGFWinRegistryKeyTest(test_lib.BaseTestCase):
 
       registry_file.Close()
 
-  @test_lib.skipUnlessHasTestFile(['NTUSER.DAT'])
   def testRecurseKeys(self):
     """Tests the RecurseKeys function."""
-    path = self._GetTestFilePath(['NTUSER.DAT'])
+    test_path = self._GetTestFilePath(['NTUSER.DAT'])
+    if not os.path.exists(test_path):
+      raise unittest.SkipTest('missing test file: NTUSER.DAT')
 
     registry_file = regf.REGFWinRegistryFile()
 
-    with open(path, 'rb') as file_object:
+    with open(test_path, 'rb') as file_object:
       registry_file.Open(file_object)
 
       key_path = '\\Software'
@@ -379,14 +394,15 @@ class REGFWinRegistryValueTest(test_lib.BaseTestCase):
 
   # pylint: disable=protected-access
 
-  @test_lib.skipUnlessHasTestFile(['NTUSER.DAT'])
   def testProperties(self):
     """Tests the properties functions on a NTUSER.DAT file."""
-    path = self._GetTestFilePath(['NTUSER.DAT'])
+    test_path = self._GetTestFilePath(['NTUSER.DAT'])
+    if not os.path.exists(test_path):
+      raise unittest.SkipTest('missing test file: NTUSER.DAT')
 
     registry_file = regf.REGFWinRegistryFile()
 
-    with open(path, 'rb') as file_object:
+    with open(test_path, 'rb') as file_object:
       registry_file.Open(file_object)
 
       registry_key = registry_file.GetKeyByPath('\\Console')
@@ -437,14 +453,15 @@ class REGFWinRegistryValueTest(test_lib.BaseTestCase):
 
       registry_file.Close()
 
-  @test_lib.skipUnlessHasTestFile(['NTUSER.DAT'])
   def testGetDataAsObject(self):
     """Tests the GetDataAsObject function."""
-    path = self._GetTestFilePath(['NTUSER.DAT'])
+    test_path = self._GetTestFilePath(['NTUSER.DAT'])
+    if not os.path.exists(test_path):
+      raise unittest.SkipTest('missing test file: NTUSER.DAT')
 
     registry_file = regf.REGFWinRegistryFile()
 
-    with open(path, 'rb') as file_object:
+    with open(test_path, 'rb') as file_object:
       registry_file.Open(file_object)
 
       registry_key = registry_file.GetKeyByPath('\\Console')

--- a/tests/registry.py
+++ b/tests/registry.py
@@ -131,9 +131,12 @@ class RegistryTest(test_lib.BaseTestCase):
 
   # pylint: disable=protected-access
 
-  @test_lib.skipUnlessHasTestFile(['SYSTEM'])
   def testGetCachedFileByPath(self):
     """Tests the _GetCachedFileByPath function."""
+    test_path = self._GetTestFilePath(['SYSTEM'])
+    if not os.path.exists(test_path):
+      raise unittest.SkipTest('missing test file: SYSTEM')
+
     win_registry = registry.WinRegistry()
 
     # Note that _GetCachedFileByPath expects the key path to be in
@@ -147,7 +150,6 @@ class RegistryTest(test_lib.BaseTestCase):
     win_registry = registry.WinRegistry(
         registry_file_reader=TestWinRegistryFileReader())
 
-    test_path = self._GetTestFilePath(['SYSTEM'])
     registry_file = win_registry._OpenFile(test_path)
     key_path_prefix = win_registry.GetRegistryFileMapping(registry_file)
     win_registry.MapFile(key_path_prefix, registry_file)
@@ -159,9 +161,12 @@ class RegistryTest(test_lib.BaseTestCase):
 
   # TODO: add tests for _GetCachedUserFileByPath
 
-  @test_lib.skipUnlessHasTestFile(['SYSTEM'])
   def testGetCurrentControlSet(self):
     """Tests the _GetCurrentControlSet function."""
+    test_path = self._GetTestFilePath(['SYSTEM'])
+    if not os.path.exists(test_path):
+      raise unittest.SkipTest('missing test file: SYSTEM')
+
     win_registry = registry.WinRegistry()
 
     registry_key = win_registry._GetCurrentControlSet('')
@@ -170,7 +175,6 @@ class RegistryTest(test_lib.BaseTestCase):
     win_registry = registry.WinRegistry(
         registry_file_reader=TestWinRegistryFileReader())
 
-    test_path = self._GetTestFilePath(['SYSTEM'])
     registry_file = win_registry._OpenFile(test_path)
     key_path_prefix = win_registry.GetRegistryFileMapping(registry_file)
     win_registry.MapFile(key_path_prefix, registry_file)
@@ -187,10 +191,16 @@ class RegistryTest(test_lib.BaseTestCase):
     registry_key = win_registry._GetCurrentControlSet('')
     self.assertIsNone(registry_key)
 
-  @test_lib.skipUnlessHasTestFile(['NTUSER.DAT'])
-  @test_lib.skipUnlessHasTestFile(['SOFTWARE'])
   def testGetUsers(self):
     """Tests the _GetUsers function."""
+    ntuser_test_path = self._GetTestFilePath(['NTUSER.DAT'])
+    if not os.path.exists(ntuser_test_path):
+      raise unittest.SkipTest('missing test file: NTUSER.DAT')
+
+    software_test_path = self._GetTestFilePath(['SOFTWARE'])
+    if not os.path.exists(software_test_path):
+      raise unittest.SkipTest('missing test file: SOFTWARE')
+
     win_registry = registry.WinRegistry()
 
     registry_key = win_registry._GetUsers('S-1-5-18')
@@ -199,13 +209,11 @@ class RegistryTest(test_lib.BaseTestCase):
     win_registry = registry.WinRegistry(
         registry_file_reader=TestWinRegistryFileReader())
 
-    test_path = self._GetTestFilePath(['NTUSER.DAT'])
-    registry_file = win_registry._OpenFile(test_path)
+    registry_file = win_registry._OpenFile(ntuser_test_path)
     profile_path = '%SystemRoot%\\System32\\config\\systemprofile\\NTUSER.DAT'
     win_registry.MapUserFile(profile_path, registry_file)
 
-    test_path = self._GetTestFilePath(['SOFTWARE'])
-    registry_file = win_registry._OpenFile(test_path)
+    registry_file = win_registry._OpenFile(software_test_path)
     key_path_prefix = win_registry.GetRegistryFileMapping(registry_file)
     win_registry.MapFile(key_path_prefix, registry_file)
 
@@ -221,16 +229,18 @@ class RegistryTest(test_lib.BaseTestCase):
     expected_key_path = 'HKEY_USERS\\.DEFAULT'
     self.assertEqual(registry_key.path, expected_key_path)
 
-  @test_lib.skipUnlessHasTestFile(['SYSTEM'])
   def testGetFileByPath(self):
     """Tests the _GetFileByPath function."""
+    test_path = self._GetTestFilePath(['SYSTEM'])
+    if not os.path.exists(test_path):
+      raise unittest.SkipTest('missing test file: SYSTEM')
+
     key_path = 'HKEY_LOCAL_MACHINE\\SYSTEM'
 
     # Test mapped file with key path prefix.
     win_registry = registry.WinRegistry(
         registry_file_reader=TestWinRegistryFileReader())
 
-    test_path = self._GetTestFilePath(['SYSTEM'])
     registry_file = win_registry._OpenFile(test_path)
     key_path_prefix = win_registry.GetRegistryFileMapping(registry_file)
     win_registry.MapFile(key_path_prefix, registry_file)
@@ -243,7 +253,6 @@ class RegistryTest(test_lib.BaseTestCase):
     win_registry = registry.WinRegistry(
         registry_file_reader=TestWinRegistryFileReader())
 
-    test_path = self._GetTestFilePath(['SYSTEM'])
     registry_file = win_registry._OpenFile(test_path)
     win_registry.MapFile('', registry_file)
 
@@ -285,13 +294,15 @@ class RegistryTest(test_lib.BaseTestCase):
     mappings = list(win_registry._GetFileMappingsByPath(key_path))
     self.assertEqual(len(mappings), 3)
 
-  @test_lib.skipUnlessHasTestFile(['NTUSER.DAT'])
   def testGetKeyByPathOnNTUserDat(self):
     """Tests the GetKeyByPath function on a NTUSER.DAT file."""
+    test_path = self._GetTestFilePath(['NTUSER.DAT'])
+    if not os.path.exists(test_path):
+      raise unittest.SkipTest('missing test file: NTUSER.DAT')
+
     win_registry = registry.WinRegistry(
         registry_file_reader=TestWinRegistryFileReader())
 
-    test_path = self._GetTestFilePath(['NTUSER.DAT'])
     registry_file = win_registry._OpenFile(test_path)
 
     win_registry = registry.WinRegistry()
@@ -317,7 +328,6 @@ class RegistryTest(test_lib.BaseTestCase):
         'HKEY_LOCAL_MACHINE\\System\\ControlSet001')
     self.assertIsNone(registry_key)
 
-  @test_lib.skipUnlessHasTestFile(['SYSTEM'])
   def testGetKeyByPathOnSystem(self):
     """Tests the GetKeyByPath function on a SYSTEM file."""
     win_registry = registry.WinRegistry(
@@ -345,23 +355,27 @@ class RegistryTest(test_lib.BaseTestCase):
     with self.assertRaises(RuntimeError):
       win_registry.GetKeyByPath('HKEY_LOCAL_MACHINE\\System\\ControlSet001')
 
-  @test_lib.skipUnlessHasTestFile(['NTUSER.DAT'])
-  @test_lib.skipUnlessHasTestFile(['NTUSER.DAT.LOG'])
   def testGetRegistryFileMappingOnNTUserDat(self):
     """Tests the GetRegistryFileMapping function on a NTUSER.DAT file."""
+    dat_test_path = self._GetTestFilePath(['NTUSER.DAT'])
+    if not os.path.exists(dat_test_path):
+      raise unittest.SkipTest('missing test file: NTUSER.DAT')
+
+    log_test_path = self._GetTestFilePath(['NTUSER.DAT.LOG'])
+    if not os.path.exists(log_test_path):
+      raise unittest.SkipTest('missing test file: NTUSER.DAT.LOG')
+
     win_registry = registry.WinRegistry(
         registry_file_reader=TestWinRegistryFileReader())
 
-    test_path = self._GetTestFilePath(['NTUSER.DAT'])
-    registry_file = win_registry._OpenFile(test_path)
+    registry_file = win_registry._OpenFile(dat_test_path)
 
     key_path_prefix = win_registry.GetRegistryFileMapping(registry_file)
     self.assertEqual(key_path_prefix, 'HKEY_CURRENT_USER')
 
     registry_file.Close()
 
-    test_path = self._GetTestFilePath(['NTUSER.DAT.LOG'])
-    registry_file = win_registry._OpenFile(test_path)
+    registry_file = win_registry._OpenFile(log_test_path)
 
     key_path_prefix = win_registry.GetRegistryFileMapping(registry_file)
     self.assertEqual(key_path_prefix, '')
@@ -371,13 +385,15 @@ class RegistryTest(test_lib.BaseTestCase):
     key_path_prefix = win_registry.GetRegistryFileMapping(None)
     self.assertEqual(key_path_prefix, '')
 
-  @test_lib.skipUnlessHasTestFile(['SYSTEM'])
   def testGetRegistryFileMappingOnSystem(self):
     """Tests the GetRegistryFileMapping function on a SYSTEM file."""
+    test_path = self._GetTestFilePath(['SYSTEM'])
+    if not os.path.exists(test_path):
+      raise unittest.SkipTest('missing test file: SYSTEM')
+
     win_registry = registry.WinRegistry(
         registry_file_reader=TestWinRegistryFileReader())
 
-    test_path = self._GetTestFilePath(['SYSTEM'])
     registry_file = win_registry._OpenFile(test_path)
 
     key_path_prefix = win_registry.GetRegistryFileMapping(registry_file)
@@ -389,26 +405,30 @@ class RegistryTest(test_lib.BaseTestCase):
 
   # TODO: add tests for GetRootKey
 
-  @test_lib.skipUnlessHasTestFile(['SYSTEM'])
   def testMapFile(self):
     """Tests the MapFile function."""
+    test_path = self._GetTestFilePath(['SYSTEM'])
+    if not os.path.exists(test_path):
+      raise unittest.SkipTest('missing test file: SYSTEM')
+
     win_registry = registry.WinRegistry(
         registry_file_reader=TestWinRegistryFileReader())
 
-    test_path = self._GetTestFilePath(['SYSTEM'])
     registry_file = win_registry._OpenFile(test_path)
 
     win_registry = registry.WinRegistry()
     key_path_prefix = win_registry.GetRegistryFileMapping(registry_file)
     win_registry.MapFile(key_path_prefix, registry_file)
 
-  @test_lib.skipUnlessHasTestFile(['NTUSER.DAT'])
   def testMapUserFile(self):
     """Tests the MapUserFile function."""
+    test_path = self._GetTestFilePath(['NTUSER.DAT'])
+    if not os.path.exists(test_path):
+      raise unittest.SkipTest('missing test file: SYSTEM')
+
     win_registry = registry.WinRegistry(
         registry_file_reader=TestWinRegistryFileReader())
 
-    test_path = self._GetTestFilePath(['NTUSER.DAT'])
     registry_file = win_registry._OpenFile(test_path)
 
     win_registry = registry.WinRegistry()

--- a/tests/registry.py
+++ b/tests/registry.py
@@ -134,8 +134,7 @@ class RegistryTest(test_lib.BaseTestCase):
   def testGetCachedFileByPath(self):
     """Tests the _GetCachedFileByPath function."""
     test_path = self._GetTestFilePath(['SYSTEM'])
-    if not os.path.exists(test_path):
-      raise unittest.SkipTest('missing test file: SYSTEM')
+    self._SkipIfPathNotExists(test_path)
 
     win_registry = registry.WinRegistry()
 
@@ -164,8 +163,7 @@ class RegistryTest(test_lib.BaseTestCase):
   def testGetCurrentControlSet(self):
     """Tests the _GetCurrentControlSet function."""
     test_path = self._GetTestFilePath(['SYSTEM'])
-    if not os.path.exists(test_path):
-      raise unittest.SkipTest('missing test file: SYSTEM')
+    self._SkipIfPathNotExists(test_path)
 
     win_registry = registry.WinRegistry()
 
@@ -194,12 +192,10 @@ class RegistryTest(test_lib.BaseTestCase):
   def testGetUsers(self):
     """Tests the _GetUsers function."""
     ntuser_test_path = self._GetTestFilePath(['NTUSER.DAT'])
-    if not os.path.exists(ntuser_test_path):
-      raise unittest.SkipTest('missing test file: NTUSER.DAT')
+    self._SkipIfPathNotExists(ntuser_test_path)
 
     software_test_path = self._GetTestFilePath(['SOFTWARE'])
-    if not os.path.exists(software_test_path):
-      raise unittest.SkipTest('missing test file: SOFTWARE')
+    self._SkipIfPathNotExists(software_test_path)
 
     win_registry = registry.WinRegistry()
 
@@ -232,8 +228,7 @@ class RegistryTest(test_lib.BaseTestCase):
   def testGetFileByPath(self):
     """Tests the _GetFileByPath function."""
     test_path = self._GetTestFilePath(['SYSTEM'])
-    if not os.path.exists(test_path):
-      raise unittest.SkipTest('missing test file: SYSTEM')
+    self._SkipIfPathNotExists(test_path)
 
     key_path = 'HKEY_LOCAL_MACHINE\\SYSTEM'
 
@@ -297,8 +292,7 @@ class RegistryTest(test_lib.BaseTestCase):
   def testGetKeyByPathOnNTUserDat(self):
     """Tests the GetKeyByPath function on a NTUSER.DAT file."""
     test_path = self._GetTestFilePath(['NTUSER.DAT'])
-    if not os.path.exists(test_path):
-      raise unittest.SkipTest('missing test file: NTUSER.DAT')
+    self._SkipIfPathNotExists(test_path)
 
     win_registry = registry.WinRegistry(
         registry_file_reader=TestWinRegistryFileReader())
@@ -358,12 +352,10 @@ class RegistryTest(test_lib.BaseTestCase):
   def testGetRegistryFileMappingOnNTUserDat(self):
     """Tests the GetRegistryFileMapping function on a NTUSER.DAT file."""
     dat_test_path = self._GetTestFilePath(['NTUSER.DAT'])
-    if not os.path.exists(dat_test_path):
-      raise unittest.SkipTest('missing test file: NTUSER.DAT')
+    self._SkipIfPathNotExists(dat_test_path)
 
     log_test_path = self._GetTestFilePath(['NTUSER.DAT.LOG'])
-    if not os.path.exists(log_test_path):
-      raise unittest.SkipTest('missing test file: NTUSER.DAT.LOG')
+    self._SkipIfPathNotExists(log_test_path)
 
     win_registry = registry.WinRegistry(
         registry_file_reader=TestWinRegistryFileReader())
@@ -388,8 +380,7 @@ class RegistryTest(test_lib.BaseTestCase):
   def testGetRegistryFileMappingOnSystem(self):
     """Tests the GetRegistryFileMapping function on a SYSTEM file."""
     test_path = self._GetTestFilePath(['SYSTEM'])
-    if not os.path.exists(test_path):
-      raise unittest.SkipTest('missing test file: SYSTEM')
+    self._SkipIfPathNotExists(test_path)
 
     win_registry = registry.WinRegistry(
         registry_file_reader=TestWinRegistryFileReader())
@@ -408,8 +399,7 @@ class RegistryTest(test_lib.BaseTestCase):
   def testMapFile(self):
     """Tests the MapFile function."""
     test_path = self._GetTestFilePath(['SYSTEM'])
-    if not os.path.exists(test_path):
-      raise unittest.SkipTest('missing test file: SYSTEM')
+    self._SkipIfPathNotExists(test_path)
 
     win_registry = registry.WinRegistry(
         registry_file_reader=TestWinRegistryFileReader())
@@ -423,8 +413,7 @@ class RegistryTest(test_lib.BaseTestCase):
   def testMapUserFile(self):
     """Tests the MapUserFile function."""
     test_path = self._GetTestFilePath(['NTUSER.DAT'])
-    if not os.path.exists(test_path):
-      raise unittest.SkipTest('missing test file: SYSTEM')
+    self._SkipIfPathNotExists(test_path)
 
     win_registry = registry.WinRegistry(
         registry_file_reader=TestWinRegistryFileReader())

--- a/tests/registry_searcher.py
+++ b/tests/registry_searcher.py
@@ -4,6 +4,7 @@
 
 from __future__ import unicode_literals
 
+import os
 import unittest
 
 from dfwinreg import fake
@@ -158,13 +159,15 @@ class WinRegistrySearcherTest(test_lib.BaseTestCase):
 
   # TODO: add tests for _FindInKey
 
-  @test_lib.skipUnlessHasTestFile(['SYSTEM'])
   def testFind(self):
     """Tests the Find function."""
+    test_path = self._GetTestFilePath(['SYSTEM'])
+    if not os.path.exists(test_path):
+      raise unittest.SkipTest('missing test file: SYSTEM')
+
     win_registry = registry.WinRegistry(
         registry_file_reader=test_registry.TestWinRegistryFileReader())
 
-    test_path = self._GetTestFilePath(['SYSTEM'])
     registry_file = win_registry._OpenFile(test_path)
 
     key_path_prefix = win_registry.GetRegistryFileMapping(registry_file)
@@ -208,13 +211,15 @@ class WinRegistrySearcherTest(test_lib.BaseTestCase):
     key_paths = list(searcher.Find())
     self.assertEqual(len(key_paths), 31351)
 
-  @test_lib.skipUnlessHasTestFile(['SYSTEM'])
   def testGetKeyByPath(self):
     """Tests the GetKeyByPath function."""
+    test_path = self._GetTestFilePath(['SYSTEM'])
+    if not os.path.exists(test_path):
+      raise unittest.SkipTest('missing test file: SYSTEM')
+
     win_registry = registry.WinRegistry(
         registry_file_reader=test_registry.TestWinRegistryFileReader())
 
-    test_path = self._GetTestFilePath(['SYSTEM'])
     registry_file = win_registry._OpenFile(test_path)
 
     key_path_prefix = win_registry.GetRegistryFileMapping(registry_file)
@@ -230,13 +235,15 @@ class WinRegistrySearcherTest(test_lib.BaseTestCase):
         'HKEY_LOCAL_MACHINE\\System\\CurrentControlSet\\Control')
     self.assertIsNotNone(registry_key)
 
-  @test_lib.skipUnlessHasTestFile(['SYSTEM'])
   def testSplitKeyPath(self):
     """Tests the SplitKeyPath function."""
+    test_path = self._GetTestFilePath(['SYSTEM'])
+    if not os.path.exists(test_path):
+      raise unittest.SkipTest('missing test file: SYSTEM')
+
     win_registry = registry.WinRegistry(
         registry_file_reader=test_registry.TestWinRegistryFileReader())
 
-    test_path = self._GetTestFilePath(['SYSTEM'])
     registry_file = win_registry._OpenFile(test_path)
 
     key_path_prefix = win_registry.GetRegistryFileMapping(registry_file)

--- a/tests/registry_searcher.py
+++ b/tests/registry_searcher.py
@@ -4,7 +4,6 @@
 
 from __future__ import unicode_literals
 
-import os
 import unittest
 
 from dfwinreg import fake
@@ -162,8 +161,7 @@ class WinRegistrySearcherTest(test_lib.BaseTestCase):
   def testFind(self):
     """Tests the Find function."""
     test_path = self._GetTestFilePath(['SYSTEM'])
-    if not os.path.exists(test_path):
-      raise unittest.SkipTest('missing test file: SYSTEM')
+    self._SkipIfPathNotExists(test_path)
 
     win_registry = registry.WinRegistry(
         registry_file_reader=test_registry.TestWinRegistryFileReader())
@@ -214,8 +212,7 @@ class WinRegistrySearcherTest(test_lib.BaseTestCase):
   def testGetKeyByPath(self):
     """Tests the GetKeyByPath function."""
     test_path = self._GetTestFilePath(['SYSTEM'])
-    if not os.path.exists(test_path):
-      raise unittest.SkipTest('missing test file: SYSTEM')
+    self._SkipIfPathNotExists(test_path)
 
     win_registry = registry.WinRegistry(
         registry_file_reader=test_registry.TestWinRegistryFileReader())
@@ -238,8 +235,7 @@ class WinRegistrySearcherTest(test_lib.BaseTestCase):
   def testSplitKeyPath(self):
     """Tests the SplitKeyPath function."""
     test_path = self._GetTestFilePath(['SYSTEM'])
-    if not os.path.exists(test_path):
-      raise unittest.SkipTest('missing test file: SYSTEM')
+    self._SkipIfPathNotExists(test_path)
 
     win_registry = registry.WinRegistry(
         registry_file_reader=test_registry.TestWinRegistryFileReader())

--- a/tests/test_lib.py
+++ b/tests/test_lib.py
@@ -23,8 +23,21 @@ class BaseTestCase(unittest.TestCase):
       path_segments (list[str]): path segments inside the test data directory.
 
     Returns:
-      str: a path of the test file.
+      str: path of the test file.
     """
     # Note that we need to pass the individual path segments to os.path.join
     # and not a list.
     return os.path.join(self._TEST_DATA_PATH, *path_segments)
+
+  def _SkipIfPathNotExists(self, path):
+    """Skips the test if the path does not exist.
+
+    Args:
+      path (str): path of a test file.
+
+    Raises:
+      SkipTest: if the path path does not exist and the test should be skipped.
+    """
+    if not os.path.exists(path):
+      filename = os.path.basename(path)
+      raise unittest.SkipTest('missing test file: {0:s}'.format(filename))

--- a/tests/test_lib.py
+++ b/tests/test_lib.py
@@ -4,32 +4,7 @@
 from __future__ import unicode_literals
 
 import os
-import sys
 import unittest
-
-
-def skipUnlessHasTestFile(path_segments):  # pylint: disable=invalid-name
-  """Decorator to skip a test if the test file does not exist.
-
-  Args:
-    path_segments (list[str]): path segments inside the test data directory.
-
-  Returns:
-    function: to invoke.
-  """
-  fail_unless_has_test_file = getattr(
-      unittest, 'fail_unless_has_test_file', False)
-
-  path = os.path.join('test_data', *path_segments)
-  if fail_unless_has_test_file or os.path.exists(path):
-    return lambda function: function
-
-  if sys.version_info[0] < 3:
-    path = path.encode('utf-8')
-
-  # Note that the message should be of type str which is different for
-  # different versions of Python.
-  return unittest.skip('missing test file: {0:s}'.format(path))
 
 
 class BaseTestCase(unittest.TestCase):

--- a/tests/virtual.py
+++ b/tests/virtual.py
@@ -4,7 +4,6 @@
 
 from __future__ import unicode_literals
 
-import os
 import unittest
 
 from dfwinreg import registry
@@ -86,8 +85,7 @@ class VirtualWinRegistryKeyTest(test_lib.BaseTestCase):
       VirtualWinRegistryKey: virtual Windows Registry key.
     """
     test_path = self._GetTestFilePath(['SYSTEM'])
-    if not os.path.exists(test_path):
-      raise unittest.SkipTest('missing test file: SYSTEM')
+    self._SkipIfPathNotExists(test_path)
 
     registry_key = virtual.VirtualWinRegistryKey(
         'HKEY_LOCAL_MACHINE', key_path='HKEY_LOCAL_MACHINE')

--- a/tests/virtual.py
+++ b/tests/virtual.py
@@ -4,6 +4,7 @@
 
 from __future__ import unicode_literals
 
+import os
 import unittest
 
 from dfwinreg import registry
@@ -84,13 +85,16 @@ class VirtualWinRegistryKeyTest(test_lib.BaseTestCase):
     Returns:
       VirtualWinRegistryKey: virtual Windows Registry key.
     """
+    test_path = self._GetTestFilePath(['SYSTEM'])
+    if not os.path.exists(test_path):
+      raise unittest.SkipTest('missing test file: SYSTEM')
+
     registry_key = virtual.VirtualWinRegistryKey(
         'HKEY_LOCAL_MACHINE', key_path='HKEY_LOCAL_MACHINE')
 
     win_registry = registry.WinRegistry(
         registry_file_reader=test_registry.TestWinRegistryFileReader())
 
-    test_path = self._GetTestFilePath(['SYSTEM'])
     registry_file = win_registry._OpenFile(test_path)
 
     key_path_prefix = win_registry.GetRegistryFileMapping(registry_file)
@@ -102,7 +106,6 @@ class VirtualWinRegistryKeyTest(test_lib.BaseTestCase):
 
     return registry_key
 
-  @test_lib.skipUnlessHasTestFile(['SYSTEM'])
   def testLastWrittenTime(self):
     """Tests the last_written_time property."""
     registry_key = self._CreateTestKeyWithMappedRegistry()
@@ -112,7 +115,6 @@ class VirtualWinRegistryKeyTest(test_lib.BaseTestCase):
 
     self.assertIsNotNone(mapped_key.last_written_time)
 
-  @test_lib.skipUnlessHasTestFile(['SYSTEM'])
   def testNumberOfSubkeys(self):
     """Tests the number_of_subkeys property."""
     registry_key = self._CreateTestKeyWithMappedRegistry()
@@ -122,7 +124,6 @@ class VirtualWinRegistryKeyTest(test_lib.BaseTestCase):
 
     self.assertEqual(mapped_key.number_of_subkeys, 9)
 
-  @test_lib.skipUnlessHasTestFile(['SYSTEM'])
   def testNumberOfValues(self):
     """Tests the number_of_values property."""
     registry_key = self._CreateTestKeyWithMappedRegistry()
@@ -138,7 +139,6 @@ class VirtualWinRegistryKeyTest(test_lib.BaseTestCase):
 
     self.assertEqual(registry_key.number_of_values, 0)
 
-  @test_lib.skipUnlessHasTestFile(['SYSTEM'])
   def testOffset(self):
     """Tests the offset property."""
     registry_key = self._CreateTestKeyWithMappedRegistry()
@@ -148,7 +148,6 @@ class VirtualWinRegistryKeyTest(test_lib.BaseTestCase):
 
     self.assertEqual(mapped_key.offset, 4132)
 
-  @test_lib.skipUnlessHasTestFile(['SYSTEM'])
   def testPropertiesWithMappedRegistry(self):
     """Tests the properties with a mapped registry."""
     registry_key = self._CreateTestKeyWithMappedRegistry()
@@ -165,7 +164,6 @@ class VirtualWinRegistryKeyTest(test_lib.BaseTestCase):
     self.assertEqual(mapped_key.number_of_values, 0)
     self.assertEqual(mapped_key.offset, 4132)
 
-  @test_lib.skipUnlessHasTestFile(['SYSTEM'])
   def testGetKeyFromRegistry(self):
     """Tests the _GetKeyFromRegistry function."""
     registry_key = self._CreateTestKeyWithMappedRegistry()
@@ -227,7 +225,6 @@ class VirtualWinRegistryKeyTest(test_lib.BaseTestCase):
     with self.assertRaises(IndexError):
       registry_key.GetSubkeyByIndex(-1)
 
-  @test_lib.skipUnlessHasTestFile(['SYSTEM'])
   def testGetSubkeyByIndexWithMappedRegistry(self):
     """Tests the GetSubkeyByIndex function with a mapped registry."""
     registry_key = self._CreateTestKeyWithMappedRegistry()
@@ -251,7 +248,6 @@ class VirtualWinRegistryKeyTest(test_lib.BaseTestCase):
     sub_registry_key = registry_key.GetSubkeyByName('Bogus')
     self.assertIsNone(sub_registry_key)
 
-  @test_lib.skipUnlessHasTestFile(['SYSTEM'])
   def testGetSubkeyByNameWithMappedRegistry(self):
     """Tests the GetSubkeyByName function with a mapped registry."""
     registry_key = self._CreateTestKeyWithMappedRegistry()
@@ -279,7 +275,6 @@ class VirtualWinRegistryKeyTest(test_lib.BaseTestCase):
     sub_registry_key = registry_key.GetSubkeyByPath(key_path)
     self.assertIsNone(sub_registry_key)
 
-  @test_lib.skipUnlessHasTestFile(['SYSTEM'])
   def testGetSubkeyByPathWithMappedRegistry(self):
     """Tests the GetSubkeyByPath function with a mapped registry."""
     registry_key = self._CreateTestKeyWithMappedRegistry()
@@ -297,7 +292,6 @@ class VirtualWinRegistryKeyTest(test_lib.BaseTestCase):
     sub_registry_keys = list(registry_key.GetSubkeys())
     self.assertEqual(len(sub_registry_keys), 2)
 
-  @test_lib.skipUnlessHasTestFile(['SYSTEM'])
   def testGetSubkeysWithMappedRegistry(self):
     """Tests the GetSubkeys function with a mapped registry."""
     registry_key = self._CreateTestKeyWithMappedRegistry()
@@ -315,7 +309,6 @@ class VirtualWinRegistryKeyTest(test_lib.BaseTestCase):
     registry_value = registry_key.GetValueByName('')
     self.assertIsNone(registry_value)
 
-  @test_lib.skipUnlessHasTestFile(['SYSTEM'])
   def testGetValueByNameWithMappedRegistry(self):
     """Tests the GetValueByName function with a mapped registry."""
     registry_key = self._CreateTestKeyWithMappedRegistry()
@@ -333,7 +326,6 @@ class VirtualWinRegistryKeyTest(test_lib.BaseTestCase):
     values = list(registry_key.GetValues())
     self.assertEqual(len(values), 0)
 
-  @test_lib.skipUnlessHasTestFile(['SYSTEM'])
   def testGetValuesWithMappedRegistry(self):
     """Tests the GetValues function with a mapped registry."""
     registry_key = self._CreateTestKeyWithMappedRegistry()


### PR DESCRIPTION
Replaced skipUnlessHasTestFile decorator with unittest.SkipTest

skipUnlessHasTestFile decorator conflicts with some build systems replacing by a runtime solution.